### PR TITLE
Refactor: Extend GitHub class as GitHubAnnos, add tests

### DIFF
--- a/annonatate/flaskserver.py
+++ b/annonatate/flaskserver.py
@@ -615,19 +615,13 @@ def getannotations():
         session['customviews'] = content['customviews']
         parsecustomviews(content)
         session['annotime'] = datetime.now()
-# diagnostic:
-        print("A: Annotations before: " + str(len(session['annotations'])))
         github.updateAnnos(session, filepath)
-        print("A: Annotations after: " + str(len(session['annotations'])))
         annotations = session['annotations']
         if status > 299:
             session['annotations'] = ''
     else:
         annotations = session['annotations']
-# diagnostic:
-        print("B: Annotations before: " + str(len(session['annotations'])))
         githubresponse = github.updateAnnos(session, filepath)
-        print("B: Annotations after: " + str(len(session['annotations'])))
         if githubresponse:
             print("githubresponse after: " + str(len(githubresponse)))
             filenames = list(map(lambda x: x['filename'].split('/')[-1], session['annotations']))

--- a/annonatate/flaskserver.py
+++ b/annonatate/flaskserver.py
@@ -615,6 +615,8 @@ def getannotations():
     if 'annotime' in session.keys():
         now = datetime.now()
         duration = (now - session['annotime']).total_seconds()
+# diagnostic:
+    print("Duration: " + str(duration))
     if 'annotations' not in session.keys() or session['annotations'] == '' or  duration > 35:
         content, status = origin_contents()
         for item in content['annotations']:
@@ -631,14 +633,21 @@ def getannotations():
         session['customviews'] = content['customviews']
         parsecustomviews(content)
         session['annotime'] = datetime.now()
+# diagnostic:
+        print("A: Annotations before: " + str(len(session['annotations'])))
         github.updateAnnos(session, filepath)
+        print("A: Annotations after: " + str(len(session['annotations'])))
         annotations = session['annotations']
         if status > 299:
             session['annotations'] = ''
     else:
         annotations = session['annotations']
+# diagnostic:
+        print("B: Annotations before: " + str(len(session['annotations'])))
         githubresponse = github.updateAnnos(session, filepath)
+        print("B: Annotations after: " + str(len(session['annotations'])))
         if githubresponse:
+            print("githubresponse after: " + str(len(githubresponse)))
             filenames = list(map(lambda x: x['filename'].split('/')[-1], session['annotations']))
             notinsession = list(filter(lambda x: x['name'] not in filenames and '-list' not in x['name'],githubresponse))
             #beforefilenames = list(map(lambda x: x['filename'].split('/')[-1], annotations))

--- a/annonatate/flaskserver.py
+++ b/annonatate/flaskserver.py
@@ -631,13 +631,13 @@ def getannotations():
         session['customviews'] = content['customviews']
         parsecustomviews(content)
         session['annotime'] = datetime.now()
-        github.updateAnnos(session)
+        github.updateAnnos(session, filepath)
         annotations = session['annotations']
         if status > 299:
             session['annotations'] = ''
     else:
         annotations = session['annotations']
-        githubresponse = github.updateAnnos(session)
+        githubresponse = github.updateAnnos(session, filepath)
         if githubresponse:
             filenames = list(map(lambda x: x['filename'].split('/')[-1], session['annotations']))
             notinsession = list(filter(lambda x: x['name'] not in filenames and '-list' not in x['name'],githubresponse))

--- a/annonatate/templates/annotations.html
+++ b/annonatate/templates/annotations.html
@@ -30,6 +30,8 @@
 {% for anno in annotations %}
 {% if 'resources' in anno['json'].keys()%}
 {% set annodata = anno['json']['resources'][0] %}
+{% elif 'items' in anno['json'].keys()%}
+{% set annodata = anno['json']['items'][0] %}
 {% else %}
 {% set annodata = anno['json'] %}
 {% endif %}

--- a/annonatate/utils/github.py
+++ b/annonatate/utils/github.py
@@ -5,49 +5,44 @@ import os, json
 import base64
 from flask_github import GitHub
 
-import pdb
-
 class GitHubAnno(GitHub):
-  def setbork(self):
-    self.bork = 'bork'
+    def get_existing(self, session, full_url):
+        payload = {'ref': session['github_branch']}
+        match = False
+        if '/images/' in full_url:
+            full_url, match = full_url.strip('/').rsplit('/', 1)
+        existing = self.raw_request('get',full_url, params=payload).json()
+        if match and type(existing) == list:
+            matches = list(filter(lambda x: x['name'] == match, existing))
+            existing = matches[0] if len(matches) > 0 else matches
+        if 'sha' in existing:
+            return existing['sha']
+        else:
+            return ''
 
-  def get_existing(self, session, full_url):
-      payload = {'ref': session['github_branch']}
-      match = False
-      if '/images/' in full_url:
-          full_url, match = full_url.strip('/').rsplit('/', 1)
-      existing = self.raw_request('get',full_url, params=payload).json()
-      if match and type(existing) == list:
-          matches = list(filter(lambda x: x['name'] == match, existing))
-          existing = matches[0] if len(matches) > 0 else matches
-      if 'sha' in existing:
-          return existing['sha']
-      else:
-          return ''
+    def sendgithubrequest(self, session, filename, annotation, path, order=''):
+        data = self.createdatadict(session, filename, annotation, path, order)
+        response = self.raw_request('put', data['url'], data=json.dumps(data['data'], indent=4))
+        return response
 
-  def sendgithubrequest(self, session, filename, annotation, path, order=''):
-      data = self.createdatadict(session, filename, annotation, path, order)
-      response = self.raw_request('put', data['url'], data=json.dumps(data['data'], indent=4))
-      return response
+    def createdatadict(self, session, filename, text, path, order=''):
+        full_url = os.path.join(session['github_url'], path, filename)
+        sha = self.get_existing(session, full_url)
+        writeordelete = "write" if text != 'delete' else "delete"
+        message = "{} {}".format(writeordelete, filename)
+        text = '---\ncanvas: "{}"\n{}---\n{}'.format(text['target']['source'],order, json.dumps(text, indent=4)) if type(text) != str and type(text) != bytes else text
+        text = text.encode('utf-8') if type(text) != bytes else text
+        data = {"message":message, "content": base64.b64encode(text).decode('utf-8'), "branch": session['github_branch'] }
+        if sha != '':
+            data['sha'] = sha
+        return {'data':data, 'url':full_url}
 
-  def createdatadict(self, session, filename, text, path, order=''):
-      full_url = os.path.join(session['github_url'], path, filename)
-      sha = self.get_existing(session, full_url)
-      writeordelete = "write" if text != 'delete' else "delete"
-      message = "{} {}".format(writeordelete, filename)
-      text = '---\ncanvas: "{}"\n{}---\n{}'.format(text['target']['source'],order, json.dumps(text, indent=4)) if type(text) != str and type(text) != bytes else text
-      text = text.encode('utf-8') if type(text) != bytes else text
-      data = {"message":message, "content": base64.b64encode(text).decode('utf-8'), "branch": session['github_branch'] }
-      if sha != '':
-          data['sha'] = sha
-      return {'data':data, 'url':full_url}
-
-  def updateAnnos(self, session):
-      annotations = session['annotations']
-      try:
-          githubresponse = self.get(session['currentworkspace']['contents_url'].replace('{+path}', filepath))
-          githubfilenames = list(map(lambda x: x['name'], githubresponse))
-          session['annotations'] = list(filter(lambda x: x['filename'].split('/')[-1] in githubfilenames,annotations))
-          return githubresponse
-      finally:
-          return False
+    def updateAnnos(self, session):
+        annotations = session['annotations']
+        try:
+            githubresponse = self.get(session['currentworkspace']['contents_url'].replace('{+path}', filepath))
+            githubfilenames = list(map(lambda x: x['name'], githubresponse))
+            session['annotations'] = list(filter(lambda x: x['filename'].split('/')[-1] in githubfilenames,annotations))
+            return githubresponse
+        finally:
+            return False

--- a/annonatate/utils/github.py
+++ b/annonatate/utils/github.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+import os, json
+import base64
+from flask_github import GitHub
+
+import pdb
+
+class GitHubAnno(GitHub):
+  def setbork(self):
+    self.bork = 'bork'
+
+  def get_existing(self, session, full_url):
+      payload = {'ref': session['github_branch']}
+      match = False
+      if '/images/' in full_url:
+          full_url, match = full_url.strip('/').rsplit('/', 1)
+      existing = self.raw_request('get',full_url, params=payload).json()
+      if match and type(existing) == list:
+          matches = list(filter(lambda x: x['name'] == match, existing))
+          existing = matches[0] if len(matches) > 0 else matches
+      if 'sha' in existing:
+          return existing['sha']
+      else:
+          return ''
+
+  def sendgithubrequest(self, session, filename, annotation, path, order=''):
+      data = self.createdatadict(session, filename, annotation, path, order)
+      response = self.raw_request('put', data['url'], data=json.dumps(data['data'], indent=4))
+      return response
+
+  def createdatadict(self, session, filename, text, path, order=''):
+      full_url = os.path.join(session['github_url'], path, filename)
+      sha = self.get_existing(session, full_url)
+      writeordelete = "write" if text != 'delete' else "delete"
+      message = "{} {}".format(writeordelete, filename)
+      text = '---\ncanvas: "{}"\n{}---\n{}'.format(text['target']['source'],order, json.dumps(text, indent=4)) if type(text) != str and type(text) != bytes else text
+      text = text.encode('utf-8') if type(text) != bytes else text
+      data = {"message":message, "content": base64.b64encode(text).decode('utf-8'), "branch": session['github_branch'] }
+      if sha != '':
+          data['sha'] = sha
+      return {'data':data, 'url':full_url}
+
+  def updateAnnos(self, session):
+      annotations = session['annotations']
+      try:
+          githubresponse = self.get(session['currentworkspace']['contents_url'].replace('{+path}', filepath))
+          githubfilenames = list(map(lambda x: x['name'], githubresponse))
+          session['annotations'] = list(filter(lambda x: x['filename'].split('/')[-1] in githubfilenames,annotations))
+          return githubresponse
+      finally:
+          return False

--- a/annonatate/utils/github.py
+++ b/annonatate/utils/github.py
@@ -37,12 +37,11 @@ class GitHubAnno(GitHub):
             data['sha'] = sha
         return {'data':data, 'url':full_url}
 
-    def updateAnnos(self, session):
-        annotations = session['annotations']
+    def updateAnnos(self, session, filepath):
         try:
             githubresponse = self.get(session['currentworkspace']['contents_url'].replace('{+path}', filepath))
             githubfilenames = list(map(lambda x: x['name'], githubresponse))
-            session['annotations'] = list(filter(lambda x: x['filename'].split('/')[-1] in githubfilenames,annotations))
+            session['annotations'] = list(filter(lambda x: x['filename'].split('/')[-1] in githubfilenames, session['annotations']))
             return githubresponse
         finally:
             return False

--- a/annonatate/utils/github.py
+++ b/annonatate/utils/github.py
@@ -43,5 +43,5 @@ class GitHubAnno(GitHub):
             githubfilenames = list(map(lambda x: x['name'], githubresponse))
             session['annotations'] = list(filter(lambda x: x['filename'].split('/')[-1] in githubfilenames, session['annotations']))
             return githubresponse
-        finally:
+        except:
             return False

--- a/test/test_github.py
+++ b/test/test_github.py
@@ -20,9 +20,9 @@ class TestGitHub(unittest.TestCase):
         def get_token_getter():
             return 'asdf'
 
-    mock_raw_request = Mock()
-    mock_raw_request.return_value.json.return_value = {'test': 'test'}
-    @patch('annonatate.utils.github.GitHubAnno.raw_request', mock_raw_request)
+    mock_github_get = Mock()
+    mock_github_get.return_value.json.return_value = {'test': 'test'}
+    @patch('annonatate.utils.github.GitHubAnno.raw_request', mock_github_get)
     def test_search_query_none(self):
         mock_session = {
             'github_url': 'https://api.github.com/repos/testuser/annonatate/contents',
@@ -43,9 +43,9 @@ class TestGitHub(unittest.TestCase):
 
 
     # with uploaded file: this will result in raw_request returning a sha value
-    mock_raw_request = Mock()
-    mock_raw_request.return_value.json.return_value = {'sha': 'sha-abcdef'}
-    @patch('annonatate.utils.github.GitHubAnno.raw_request', mock_raw_request)
+    mock_github_get = Mock()
+    mock_github_get.return_value.json.return_value = {'sha': 'sha-abcdef'}
+    @patch('annonatate.utils.github.GitHubAnno.raw_request', mock_github_get)
     def test_search_query_upload(self):
         mock_session = {
             'github_url': 'https://api.github.com/repos/testuser/annonatate/contents',
@@ -61,24 +61,24 @@ class TestGitHub(unittest.TestCase):
         self.assertEqual(datadict['data']['sha'], 'sha-abcdef')
 
     # test deletion of session annotations that have been deleted in Github repo (e.g. by another user)
-    keep_annotation = { "name": "annotation_to_keep", "filename": "http://test/annotation_to_keep" }
-    delete_annotation =   { "name": "annotation_to_delete", "filename": "http://test/annotation_to_delete" }
+    keep_annotation_github = { "name": "annotation_to_keep" }
+    keep_annotation_session = { "filename": "http://test/annotation_to_keep" }
+    delete_annotation_session = { "filename": "http://test/annotation_to_delete" }
 
-    mock_raw_request = MagicMock()
-    mock_raw_request.return_value = [keep_annotation]
-    @patch('annonatate.utils.github.GitHubAnno.get', mock_raw_request)
+    mock_github_get = MagicMock()
+    mock_github_get.return_value = [keep_annotation_github]
+    @patch('annonatate.utils.github.GitHubAnno.get', mock_github_get)
     def test_updateAnnos(self):
         test_session = {
             'currentworkspace': {
                 'contents_url': 'https://api.github.com/repos/testuser/annonatate/contents/{+path}'
             },
-            'annotations': [self.keep_annotation, self.delete_annotation]
+            'annotations': [self.keep_annotation_session, self.delete_annotation_session]
         }
-        filepath = '_annotations' # TODO: make sure this is assigned properly
+        filepath = '_annotations'
         self.github.updateAnnos(test_session, filepath)
-        self.assertIn('annotations', test_session)
         self.assertEqual(len(test_session['annotations']), 1) # one has been deleted
-        self.assertEqual(test_session['annotations'][0]['name'], self.keep_annotation['name']) # right one has been kept
+        self.assertEqual(test_session['annotations'][0]['filename'], self.keep_annotation_session['filename']) # right one has been kept
 
 if __name__ == '__main__':
     # begin the unittest.main()

--- a/test/test_github.py
+++ b/test/test_github.py
@@ -12,55 +12,54 @@ import ast
 
 class TestGitHub(unittest.TestCase):
 
-  def setUp(self):
-    print("setup")
-    self.github = anno.GitHubAnno(None)
-    self.session = {'github_branch': 'gb', 'github_url': 'https://api.github.com/repos/testuser/annonatate/contents'}
+    def setUp(self):
+        self.github = anno.GitHubAnno(None)
+        self.session = {'github_branch': 'gb', 'github_url': 'https://api.github.com/repos/testuser/annonatate/contents'}
 
-    @self.github.access_token_getter
-    def get_token_getter():
-        return 'asdf'
+        @self.github.access_token_getter
+        def get_token_getter():
+            return 'asdf'
 
-  mock_raw_request = Mock()
-  mock_raw_request.return_value.json.return_value = {'test': 'test'}
-  @patch('annonatate.utils.github.GitHubAnno.raw_request', mock_raw_request)
-  def test_search_query_none(self):
-    mock_session = {
-      'github_url': 'https://api.github.com/repos/testuser/annonatate/contents',
-      'github_branch': 'gb'
-    }
+    mock_raw_request = Mock()
+    mock_raw_request.return_value.json.return_value = {'test': 'test'}
+    @patch('annonatate.utils.github.GitHubAnno.raw_request', mock_raw_request)
+    def test_search_query_none(self):
+        mock_session = {
+            'github_url': 'https://api.github.com/repos/testuser/annonatate/contents',
+            'github_branch': 'gb'
+        }
 
-    datadict = self.github.createdatadict(
-      mock_session,
-      'testimage.jpg',
-      'text of image',
-      'images',
-      ''
-    )
-    self.assertEqual(datadict['data']['message'], 'write testimage.jpg')
-    self.assertEqual(datadict['data']['content'], 'dGV4dCBvZiBpbWFnZQ==')
-    self.assertNotIn('sha', datadict['data'])
-    self.assertEqual(datadict['url'], 'https://api.github.com/repos/testuser/annonatate/contents/images/testimage.jpg')
+        datadict = self.github.createdatadict(
+            mock_session,
+            'testimage.jpg',
+            'text of image',
+            'images',
+            ''
+        )
+        self.assertEqual(datadict['data']['message'], 'write testimage.jpg')
+        self.assertEqual(datadict['data']['content'], 'dGV4dCBvZiBpbWFnZQ==')
+        self.assertNotIn('sha', datadict['data'])
+        self.assertEqual(datadict['url'], 'https://api.github.com/repos/testuser/annonatate/contents/images/testimage.jpg')
 
 
-  # with uploaded file: this will result in raw_request returning a sha value
-  mock_raw_request = Mock()
-  mock_raw_request.return_value.json.return_value = {'sha': 'sha-abcdef'}
-  @patch('annonatate.utils.github.GitHubAnno.raw_request', mock_raw_request)
-  def test_search_query_upload(self):
-    mock_session = {
-      'github_url': 'https://api.github.com/repos/testuser/annonatate/contents',
-      'github_branch': 'gb'
-    }
-    datadict = self.github.createdatadict(
-      mock_session,
-      'testimage.jpg',
-      'text of image',
-      'images',
-      ''
-    )
-    self.assertEqual(datadict['data']['sha'], 'sha-abcdef')
+    # with uploaded file: this will result in raw_request returning a sha value
+    mock_raw_request = Mock()
+    mock_raw_request.return_value.json.return_value = {'sha': 'sha-abcdef'}
+    @patch('annonatate.utils.github.GitHubAnno.raw_request', mock_raw_request)
+    def test_search_query_upload(self):
+        mock_session = {
+            'github_url': 'https://api.github.com/repos/testuser/annonatate/contents',
+            'github_branch': 'gb'
+        }
+        datadict = self.github.createdatadict(
+            mock_session,
+            'testimage.jpg',
+            'text of image',
+            'images',
+            ''
+        )
+        self.assertEqual(datadict['data']['sha'], 'sha-abcdef')
 
 if __name__ == '__main__':
-   # begin the unittest.main()
-   unittest.main()
+    # begin the unittest.main()
+    unittest.main()

--- a/test/test_github.py
+++ b/test/test_github.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+import unittest
+from unittest.mock import Mock
+from unittest.mock import patch
+import flask_github
+
+import annonatate.utils.github as anno
+import json
+import ast
+
+class TestGitHub(unittest.TestCase):
+
+  def setUp(self):
+    print("setup")
+    self.github = anno.GitHubAnno(None)
+    self.session = {'github_branch': 'gb', 'github_url': 'https://api.github.com/repos/testuser/annonatate/contents'}
+
+    @self.github.access_token_getter
+    def get_token_getter():
+        return 'asdf'
+
+  mock_raw_request = Mock()
+  mock_raw_request.return_value.json.return_value = {'test': 'test'}
+  @patch('annonatate.utils.github.GitHubAnno.raw_request', mock_raw_request)
+  def test_search_query_none(self):
+    mock_session = {
+      'github_url': 'https://api.github.com/repos/testuser/annonatate/contents',
+      'github_branch': 'gb'
+    }
+
+    datadict = self.github.createdatadict(
+      mock_session,
+      'testimage.jpg',
+      'text of image',
+      'images',
+      ''
+    )
+    self.assertEqual(datadict['data']['message'], 'write testimage.jpg')
+    self.assertEqual(datadict['data']['content'], 'dGV4dCBvZiBpbWFnZQ==')
+    self.assertNotIn('sha', datadict['data'])
+    self.assertEqual(datadict['url'], 'https://api.github.com/repos/testuser/annonatate/contents/images/testimage.jpg')
+
+
+  # with uploaded file: this will result in raw_request returning a sha value
+  mock_raw_request = Mock()
+  mock_raw_request.return_value.json.return_value = {'sha': 'sha-abcdef'}
+  @patch('annonatate.utils.github.GitHubAnno.raw_request', mock_raw_request)
+  def test_search_query_upload(self):
+    mock_session = {
+      'github_url': 'https://api.github.com/repos/testuser/annonatate/contents',
+      'github_branch': 'gb'
+    }
+    datadict = self.github.createdatadict(
+      mock_session,
+      'testimage.jpg',
+      'text of image',
+      'images',
+      ''
+    )
+    self.assertEqual(datadict['data']['sha'], 'sha-abcdef')
+
+if __name__ == '__main__':
+   # begin the unittest.main()
+   unittest.main()


### PR DESCRIPTION
This PR extracts the github utility functions from flaskserver.py and incorporates them into a new class GitHubAnnos, which extends GitHub (from github-flask). There's not much to test here (since we're not going to test the GitHub API) but I've added a couple of tests of createdatadict to show that it is making the correct choices based on input.